### PR TITLE
[Closes #6] Record order cancellations

### DIFF
--- a/alembic/versions/47c6d9c6fd29_add_order_fill_column_to_orders_table.py
+++ b/alembic/versions/47c6d9c6fd29_add_order_fill_column_to_orders_table.py
@@ -1,0 +1,29 @@
+"""Add order fill column to Orders table
+
+Revision ID: 47c6d9c6fd29
+Revises: 7661fdf74566
+Create Date: 2018-01-21 17:12:03.082114
+
+"""
+from alembic import op
+from decimal import Decimal
+from sqlalchemy import Column, Integer
+
+import os.path, sys
+sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+from common_types import SA_TYPE_VALUE
+
+
+# revision identifiers, used by Alembic.
+revision = '47c6d9c6fd29'
+down_revision = '7661fdf74566'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column("orders",
+        Column("amount_fill", SA_TYPE_VALUE))
+
+def downgrade():
+    op.drop_column("orders", "amount_fill")

--- a/alembic/versions/4ce9876eea54_add_updated_datetime_column_to_orders.py
+++ b/alembic/versions/4ce9876eea54_add_updated_datetime_column_to_orders.py
@@ -1,0 +1,23 @@
+"""Add updated datetime column to Orders
+
+Revision ID: 4ce9876eea54
+Revises: 47c6d9c6fd29
+Create Date: 2018-01-22 19:27:51.969849
+
+"""
+from alembic import op
+from sqlalchemy import Column, DateTime
+
+
+# revision identifiers, used by Alembic.
+revision = '4ce9876eea54'
+down_revision = '47c6d9c6fd29'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column("orders", Column("updated", DateTime))
+
+def downgrade():
+    op.drop_column("orders", "updated")

--- a/contract_event_recorders.py
+++ b/contract_event_recorders.py
@@ -1,72 +1,92 @@
 from app import App
-from contract_event_utils import block_timestamp
+from contract_event_utils import block_timestamp, coerce_to_int, parse_insert_status
 from datetime import datetime, timezone
 import logging
 from pprint import pprint
 from web3 import Web3
 
+logger = logging.getLogger("contract_event_recorders")
+
+INSERT_TRADE_STMT = """
+    INSERT INTO trades
+    (
+        "block_number", "transaction_hash", "log_index",
+        "token_give", "amount_give", "token_get", "amount_get",
+        "addr_give", "addr_get", "date"
+    )
+    VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
+    ON CONFLICT ON CONSTRAINT index_trades_on_event_identifier DO NOTHING;
+"""
 async def record_trade(event_name, event):
-    logger = logging.getLogger("contract_events")
-    insert_statement = """INSERT INTO trades
-        (
-            "block_number", "transaction_hash", "log_index",
-            "token_give", "amount_give", "token_get", "amount_get",
-            "addr_give", "addr_get", "date"
-        )
-        VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
-        ON CONFLICT ON CONSTRAINT index_trades_on_event_identifier DO NOTHING;"""
+    block_number = coerce_to_int(event["blockNumber"])
+    log_index = coerce_to_int(event["logIndex"])
+    date = datetime.fromtimestamp(block_timestamp(App().web3, event["blockNumber"]), tz=None)
 
     insert_args = (
-        event["blockNumber"] if isinstance(event["blockNumber"], int) else Web3.toInt(hexstr=event["blockNumber"]),
+        block_number,
         Web3.toBytes(hexstr=event["transactionHash"]),
-        event["logIndex"] if isinstance(event["logIndex"], int) else Web3.toInt(hexstr=event["logIndex"]),
+        log_index,
         Web3.toBytes(hexstr=event["args"]["tokenGive"]),
         event["args"]["amountGive"],
         Web3.toBytes(hexstr=event["args"]["tokenGet"]),
         event["args"]["amountGet"],
         Web3.toBytes(hexstr=event["args"]["give"]),
         Web3.toBytes(hexstr=event["args"]["get"]),
-        datetime.fromtimestamp(block_timestamp(App().web3, event["blockNumber"]), tz=None)
+        date
     )
 
     async with App().db.acquire_connection() as connection:
-        await connection.execute(insert_statement, *insert_args)
-    logger.debug("recorded trade txid=%s, logidx=%i", event["transactionHash"], event["logIndex"] if isinstance(event["logIndex"], int) else Web3.toInt(hexstr=event["logIndex"]))
+        insert_retval = await connection.execute(INSERT_TRADE_STMT, *insert_args)
+        _, _, did_insert = parse_insert_status(insert_retval)
+
+    if did_insert:
+        logger.debug("recorded trade txid=%s, logidx=%i", event["transactionHash"], log_index)
+
+    return bool(did_insert)
 
 async def record_deposit(event_name, event):
-    logger = logging.getLogger("contract_observer")
-    await record_transfer("DEPOSIT", event)
-    logger.info("recorded deposit txid=%s, logidx=%i", event["transactionHash"], event["logIndex"] if isinstance(event["logIndex"], int) else Web3.toInt(hexstr=event["logIndex"]))
+    did_insert = await record_transfer("DEPOSIT", event)
+    if did_insert:
+        logger.info("recorded deposit txid=%s, logidx=%i", event["transactionHash"], coerce_to_int(event["logIndex"]))
+    return did_insert
 
 async def record_withdraw(event_name, event):
-    logger = logging.getLogger("contract_observer")
-    await record_transfer("WITHDRAW", event)
-    logger.info("recorded deposit txid=%s, logidx=%i", event["transactionHash"], event["logIndex"] if isinstance(event["logIndex"], int) else Web3.toInt(hexstr=event["logIndex"]))
+    did_insert = await record_transfer("WITHDRAW", event)
+    if did_insert:
+        logger.info("recorded withdraw txid=%s, logidx=%i", event["transactionHash"], coerce_to_int(event["logIndex"]))
+    return did_insert
 
-async def record_transfer(transfer_direction, event):
-    insert_statement = """
+INSERT_TRANSFER_STMT = """
     INSERT INTO transfers
-        (
-            "block_number", "transaction_hash", "log_index",
-            "direction", "token", "user", "amount", "balance_after", "date"
-        )
-        VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
-        ON CONFLICT ON CONSTRAINT index_transfers_on_event_identifier DO NOTHING;"""
+    (
+        "block_number", "transaction_hash", "log_index",
+        "direction", "token", "user", "amount", "balance_after", "date"
+    )
+    VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
+    ON CONFLICT ON CONSTRAINT index_transfers_on_event_identifier DO NOTHING;
+"""
+async def record_transfer(transfer_direction, event):
+    block_number = coerce_to_int(event["blockNumber"])
+    log_index = coerce_to_int(event["logIndex"])
+    date = datetime.fromtimestamp(block_timestamp(App().web3, block_number), tz=None)
 
     insert_args = (
-        event["blockNumber"] if isinstance(event["blockNumber"], int) else Web3.toInt(hexstr=event["blockNumber"]),
+        block_number,
         Web3.toBytes(hexstr=event["transactionHash"]),
-        event["logIndex"] if isinstance(event["logIndex"], int) else Web3.toInt(hexstr=event["logIndex"]),
+        log_index,
         transfer_direction,
         Web3.toBytes(hexstr=event["args"]["token"]),
         Web3.toBytes(hexstr=event["args"]["user"]),
         event["args"]["amount"],
         event["args"]["balance"],
-        datetime.fromtimestamp(block_timestamp(App().web3, event["blockNumber"]), tz=None)
+        date
     )
 
     async with App().db.acquire_connection() as connection:
-        await connection.execute(insert_statement, *insert_args)
+        insert_retval = await connection.execute(INSERT_TRANSFER_STMT, *insert_args)
+        _, _, did_insert = parse_insert_status(insert_retval)
+
+    return bool(did_insert)
 
 def record_cancel(event_name, event):
     print("record_cancel", event)

--- a/contract_event_recorders.py
+++ b/contract_event_recorders.py
@@ -1,8 +1,9 @@
 from app import App
-from contract_event_utils import block_timestamp, coerce_to_int, parse_insert_status
+from contract_event_utils import block_timestamp
 from datetime import datetime, timezone
 import logging
 from pprint import pprint
+from utils import coerce_to_int, parse_insert_status
 from web3 import Web3
 
 ZERO_ADDR = "0x0000000000000000000000000000000000000000"

--- a/contract_event_recorders.py
+++ b/contract_event_recorders.py
@@ -5,7 +5,75 @@ import logging
 from pprint import pprint
 from web3 import Web3
 
+ZERO_ADDR = "0x0000000000000000000000000000000000000000"
+
 logger = logging.getLogger("contract_event_recorders")
+logger.setLevel(logging.DEBUG)
+
+async def process_trade(contract, event_name, event):
+    logger.debug("received trade txid=%s", event["transactionHash"])
+    did_insert = await record_trade(contract, event_name, event)
+
+    if did_insert:
+        logger.info("recorded trade txid=%s, logidx=%i",
+                    event["transactionHash"],
+                    coerce_to_int(event["logIndex"]))
+
+        # Get a list of potentially affected orders (any order from this maker and non-base token)
+        block_number = coerce_to_int(event["blockNumber"])
+        # Order maker side is recorded in `get`
+        order_maker = event["args"]["get"]
+        if event["args"]["tokenGive"] != ZERO_ADDR:
+            coin_addr = event["args"]["tokenGive"]
+        else:
+            coin_addr = event["args"]["tokenGet"]
+
+        affected_orders = await fetch_affected_orders(order_maker, coin_addr, block_number)
+        if len(affected_orders) > 0:
+            logger.debug("updating up to %i orders for trade txid=%s",
+                            len(affected_orders), event["transactionHash"])
+            await update_order_fills(contract, affected_orders)
+        else:
+            logger.warn("No orders found for user='%s' and token='%s'", order_maker, coin_addr)
+        logger.debug("done order updates for txid=%s", event["transactionHash"])
+    else:
+        logger.debug("duplicate trade txid=%s", event["transactionHash"])
+
+
+FETCH_AFFECTED_ORDERS_STMT = """
+    SELECT *
+    FROM orders
+    WHERE "user" = $1
+        AND ("token_give" = $2 OR "token_get" = $2)
+        AND "expires" >= $3
+"""
+async def fetch_affected_orders(order_maker, coin_addr, expiring_at):
+    async with App().db.acquire_connection() as conn:
+        return await conn.fetch(
+            FETCH_AFFECTED_ORDERS_STMT,
+            Web3.toBytes(hexstr=order_maker),
+            Web3.toBytes(hexstr=coin_addr),
+            expiring_at)
+
+UPDATE_ORDER_FILL_STMT = """
+    UPDATE "orders"
+    SET "amount_fill" = GREATEST("amount_fill", $1),
+        "state" = (CASE
+                    WHEN "state" IN ('FILLED'::orderstate, 'CANCELED'::orderstate) THEN "state"
+                    WHEN ("amount_get" <= GREATEST("amount_fill", $1)) THEN 'FILLED'::orderstate
+                    ELSE 'OPEN'::orderstate END)
+    WHERE "signature" = $2
+"""
+async def update_order_fills(contract, orders):
+    order_fills = contract.call().orderFills
+    for order in orders:
+        order_maker = Web3.toHex(order["user"])
+        order_signature = Web3.toBytes(order["signature"])
+
+        amount_fill = order_fills(order_maker, order_signature)
+        update_args = (amount_fill, order_signature)
+        async with App().db.acquire_connection() as conn:
+            await conn.execute(UPDATE_ORDER_FILL_STMT, *update_args)
 
 INSERT_TRADE_STMT = """
     INSERT INTO trades
@@ -17,7 +85,7 @@ INSERT_TRADE_STMT = """
     VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
     ON CONFLICT ON CONSTRAINT index_trades_on_event_identifier DO NOTHING;
 """
-async def record_trade(event_name, event):
+async def record_trade(contract, event_name, event):
     block_number = coerce_to_int(event["blockNumber"])
     log_index = coerce_to_int(event["logIndex"])
     date = datetime.fromtimestamp(block_timestamp(App().web3, event["blockNumber"]), tz=None)
@@ -44,13 +112,13 @@ async def record_trade(event_name, event):
 
     return bool(did_insert)
 
-async def record_deposit(event_name, event):
+async def record_deposit(contract, event_name, event):
     did_insert = await record_transfer("DEPOSIT", event)
     if did_insert:
         logger.info("recorded deposit txid=%s, logidx=%i", event["transactionHash"], coerce_to_int(event["logIndex"]))
     return did_insert
 
-async def record_withdraw(event_name, event):
+async def record_withdraw(contract, event_name, event):
     did_insert = await record_transfer("WITHDRAW", event)
     if did_insert:
         logger.info("recorded withdraw txid=%s, logidx=%i", event["transactionHash"], coerce_to_int(event["logIndex"]))
@@ -88,5 +156,5 @@ async def record_transfer(transfer_direction, event):
 
     return bool(did_insert)
 
-def record_cancel(event_name, event):
+def record_cancel(contract, event_name, event):
     print("record_cancel", event)

--- a/contract_event_utils.py
+++ b/contract_event_utils.py
@@ -1,3 +1,5 @@
+from web3 import Web3
+
 block_timestamp_cache = {}
 def block_timestamp(web3, block_number):
     global block_timestamp_cache
@@ -5,3 +7,20 @@ def block_timestamp(web3, block_number):
         block_timestamp_cache[block_number] = web3.eth.getBlock(block_number)["timestamp"]
 
     return block_timestamp_cache[block_number]
+
+def coerce_to_int(value):
+    '''
+    Normalizes event values to integers, since WS API returns numbers, and HTTP
+     API returns hexstr.
+    '''
+    if isinstance(value, int):
+        return value
+    return Web3.toInt(hexstr=value)
+
+def parse_insert_status(status_string):
+    '''
+    Returns (command, oid, count) tuple from INSERT status string.
+    cf. https://stackoverflow.com/q/3835314/215024
+    '''
+    command, oid, count = status_string.split(" ")
+    return (command, oid, int(count))

--- a/contract_event_utils.py
+++ b/contract_event_utils.py
@@ -1,5 +1,3 @@
-from web3 import Web3
-
 block_timestamp_cache = {}
 def block_timestamp(web3, block_number):
     global block_timestamp_cache
@@ -7,20 +5,3 @@ def block_timestamp(web3, block_number):
         block_timestamp_cache[block_number] = web3.eth.getBlock(block_number)["timestamp"]
 
     return block_timestamp_cache[block_number]
-
-def coerce_to_int(value):
-    '''
-    Normalizes event values to integers, since WS API returns numbers, and HTTP
-     API returns hexstr.
-    '''
-    if isinstance(value, int):
-        return value
-    return Web3.toInt(hexstr=value)
-
-def parse_insert_status(status_string):
-    '''
-    Returns (command, oid, count) tuple from INSERT status string.
-    cf. https://stackoverflow.com/q/3835314/215024
-    '''
-    command, oid, count = status_string.split(" ")
-    return (command, oid, int(count))

--- a/contract_event_utils.py
+++ b/contract_event_utils.py
@@ -1,7 +1,7 @@
 block_timestamp_cache = {}
 def block_timestamp(web3, block_number):
     global block_timestamp_cache
-    if block_number not in block_timestamp_cache:
+    if not isinstance(block_number, int) or block_number not in block_timestamp_cache:
         block_timestamp_cache[block_number] = web3.eth.getBlock(block_number)["timestamp"]
 
     return block_timestamp_cache[block_number]

--- a/contract_events_backfill.py
+++ b/contract_events_backfill.py
@@ -1,14 +1,14 @@
 from app import App
 import asyncio
 from config import ED_CONTRACT_ADDR, ED_CONTRACT_ABI, HTTP_PROVIDER_URL
-from contract_event_recorders import record_cancel, record_deposit, record_trade, record_withdraw
+from contract_event_recorders import record_cancel, record_deposit, process_trade, record_withdraw
 import sys
 from time import time, sleep
 from web3 import Web3, HTTPProvider
 
 BLOCK_ALIASES = ("latest", "earliest", "pending")
 EVENT_HANDLERS = {
-    'Trade': record_trade,
+    'Trade': process_trade,
     'Deposit': record_deposit,
     'Withdraw': record_withdraw,
     'Cancel': record_cancel,
@@ -38,7 +38,7 @@ async def main():
             print(int(time()), block_number - block_step, block_number, total_events)
             event_filter = ed_contract.on(event_name, {'fromBlock': block_number - block_step, 'toBlock': block_number })
             for event in event_filter.get(only_changes=False):
-                await EVENT_HANDLERS[event_name](event_name, event)
+                await EVENT_HANDLERS[event_name](ed_contract, event_name, event)
                 total_events += 1
             sleep(3)
         finally:

--- a/contract_observer.py
+++ b/contract_observer.py
@@ -4,10 +4,11 @@ from app import App
 import asyncio
 from config import ED_CONTRACT_ADDR, ED_CONTRACT_ABI, WS_PROVIDER_URL
 from contract_event_recorders import record_cancel, record_deposit, process_trade, record_withdraw
-from contract_event_utils import block_timestamp, coerce_to_int
+from contract_event_utils import block_timestamp
 import json
 import logging
 from time import time
+from utils import coerce_to_int
 from websockets import connect
 from websocket_filter_set import WebsocketFilterSet
 

--- a/etherdelta_observer.py
+++ b/etherdelta_observer.py
@@ -2,7 +2,7 @@
 
 from app import App
 import asyncio
-from config import ED_WS_SERVERS
+from config import ED_CONTRACT_ADDR, ED_CONTRACT_ABI, ED_WS_SERVERS
 from datetime import datetime
 from decimal import Decimal
 import json
@@ -14,6 +14,7 @@ from queue import Queue, Empty as QueueEmpty
 from random import sample
 from socketio_client import SocketIOClient
 from time import time
+from utils import parse_insert_status
 from web3 import Web3
 from websockets.exceptions import ConnectionClosed, InvalidStatusCode
 
@@ -28,6 +29,9 @@ market_queue = Queue()
 with open("tokens.json") as f:
     for token in json.load(f):
         market_queue.put(token["addr"].lower())
+
+web3 = App().web3
+contract = web3.eth.contract(ED_CONTRACT_ADDR, abi=ED_CONTRACT_ABI)
 
 async def on_connect(io_client, event):
     logger.info("ED API client connected to %s", io_client.ws_url)
@@ -74,16 +78,27 @@ async def on_pong(io_client, event):
             await asyncio.sleep(4)
             market_queue.put(token)
 
+INSERT_ORDER_STMT = """
+    INSERT INTO orders
+    (
+        "source", "signature",
+        "token_give", "amount_give", "token_get", "amount_get",
+        "expires", "nonce", "user", "state", "v", "r", "s", "date"
+    )
+    VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14)
+    ON CONFLICT ON CONSTRAINT index_orders_on_signature DO NOTHING
+"""
+UPDATE_ORDER_FILL_STMT = """
+    UPDATE "orders"
+    SET "amount_fill" = GREATEST("amount_fill", $1),
+        "state" = (CASE
+                    WHEN "state" IN ('FILLED'::orderstate, 'CANCELED'::orderstate) THEN "state"
+                    WHEN ("amount_get" <= GREATEST("amount_fill", $1)) THEN 'FILLED'::orderstate
+                    ELSE 'OPEN'::orderstate END)
+    WHERE "signature" = $2
+""" # Totally a duplicate of contract event recorder SQL
 async def record_order(order):
-    insert_statement = """INSERT INTO orders
-        (
-            "source", "signature",
-            "token_give", "amount_give", "token_get", "amount_get",
-            "expires", "nonce", "user", "state", "v", "r", "s", "date"
-        )
-        VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14)
-        ON CONFLICT ON CONSTRAINT index_orders_on_signature DO NOTHING;"""
-
+    order_maker = order["user"]
     signature = make_order_hash(order)
     insert_args = (
         OrderSource.OFFCHAIN.name,
@@ -103,8 +118,18 @@ async def record_order(order):
     )
 
     async with App().db.acquire_connection() as connection:
-        await connection.execute(insert_statement, *insert_args)
-    logger.info("recorded order signature=%s, user=%s, expires=%i", signature, order["user"], int(order["expires"]))
+        insert_retval = await connection.execute(INSERT_ORDER_STMT, *insert_args)
+        _, _, did_insert = parse_insert_status(insert_retval)
+
+    if did_insert:
+        logger.info("recorded order signature=%s, user=%s, expires=%i", signature, order["user"], int(order["expires"]))
+        amount_fill = contract.call().orderFills(order_maker, Web3.toBytes(hexstr=signature))
+        update_args = (amount_fill, Web3.toBytes(hexstr=signature))
+        async with App().db.acquire_connection() as conn:
+            await conn.execute(UPDATE_ORDER_FILL_STMT, *update_args)
+        logger.info("update order signature=%s fill=%i", signature, amount_fill)
+    else:
+        logger.debug("duplicate order signature=%s", signature)
 
 async def main(my_id, num_observers):
     ws_url = ED_WS_SERVERS[my_id]

--- a/socketio_client.py
+++ b/socketio_client.py
@@ -19,8 +19,6 @@ SOCKETIO_OPEN = "0"
 SOCKETIO_EVENT = "2"
 SOCKETIO_IGNORABLE = frozenset((SOCKETIO_OPEN, ))
 
-LOG_FORMAT = '%(asctime)s %(name)-12s %(levelname)-8s %(message)s'
-
 class SocketIOClient:
     def __init__(self, ws_url,
         ping_interval=ENGINEIO_PING_INTERVAL,
@@ -128,6 +126,5 @@ class SocketIOClient:
                 logger.debug("Unhandled event '%s'", event_name)
 
     def __configure_loggers(self):
-        logging.basicConfig(format=LOG_FORMAT)
         for (logger_name, logger_level) in (('websockets', logging.WARN), ('engineio', logging.WARN), ('socketio', logging.INFO)):
             logging.getLogger(logger_name).setLevel(logger_level)

--- a/utils.py
+++ b/utils.py
@@ -1,0 +1,18 @@
+from web3 import Web3
+
+def coerce_to_int(value):
+    '''
+    Normalizes event values to integers, since WS API returns numbers, and HTTP
+     API returns hexstr.
+    '''
+    if isinstance(value, int):
+        return value
+    return Web3.toInt(hexstr=value)
+
+def parse_insert_status(status_string):
+    '''
+    Returns (command, oid, count) tuple from INSERT status string.
+    cf. https://stackoverflow.com/q/3835314/215024
+    '''
+    command, oid, count = status_string.split(" ")
+    return (command, oid, int(count))

--- a/websocket_filter_set.py
+++ b/websocket_filter_set.py
@@ -26,11 +26,11 @@ class WebsocketFilterSet:
             if iscoroutinefunction(handler_func):
                 async def decorated(payload):
                     event_data = get_event_data(event_abi, payload)
-                    return await handler_func(event_name, event_data)
+                    return await handler_func(self.contract, event_name, event_data)
             else:
                 def decorated(payload):
                     event_data = get_event_data(event_abi, payload)
-                    return handler_func(event_name, event_data)
+                    return handler_func(self.contract, event_name, event_data)
 
             self.topic_filters.append(event_filter_params)
             self.handlers[event_filter_params["topics"][0]] = decorated

--- a/websocket_server.py
+++ b/websocket_server.py
@@ -99,7 +99,7 @@ async def get_transfers(token_hexstr, user_hexstr):
             Web3.toBytes(hexstr=token_hexstr),
             Web3.toBytes(hexstr=ZERO_ADDR))
 
-async def get_orders(token_give_hexstr, token_get_hexstr, user_hexstr=None, expires_after=None, sort=None):
+async def get_orders(token_give_hexstr, token_get_hexstr, user_hexstr=None, expires_after=None, state=None, sort=None):
     where = '("token_give" = $1 AND "token_get" = $2)'
     placeholder_args = [
         Web3.toBytes(hexstr=token_give_hexstr),
@@ -113,6 +113,10 @@ async def get_orders(token_give_hexstr, token_get_hexstr, user_hexstr=None, expi
     if expires_after:
         where += ' AND ("expires" > ${})'.format(len(placeholder_args) + 1)
         placeholder_args.append(expires_after)
+
+    if state:
+        where += ' AND ("state" = ${})'.format(len(placeholder_args) + 1)
+        placeholder_args.append(state)
 
     order_by = ['expires ASC']
     if sort is not None:
@@ -195,9 +199,11 @@ async def get_market(sid, data):
     if token:
         trades = await get_trades(token)
         orders_buys = await get_orders(ZERO_ADDR, token,
+                                        state=OrderState.OPEN.name,
                                         sort="(amount_give / amount_get) DESC",
                                         expires_after=current_block)
         orders_sells = await get_orders(token, ZERO_ADDR,
+                                        state=OrderState.OPEN.name,
                                         sort="(amount_get / amount_give) ASC",
                                         expires_after=current_block)
         if user:


### PR DESCRIPTION
This PR is based on top of #5.

When we receive a `Cancel` event, upsert (update or insert) an order with matching details, `amount_fill` set to `amountGet` of the original order, and `state = CANCELED`.

If the order is once picked up/processed by etherdelta observer after it has been cancelled, no modifications will be made.