### PR TITLE
Make separate docker-compose environments

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,8 @@ Requirements:
 Setup:
 1. Clone the repo (git clone https://github.com/forkdelta/backend-replacement.git)
 2. Navigate to the root of the working copy, where the README file is.
-3. Rename/copy `default.env` file to `.env` in root
+3. Rename/copy `default.env` file to `.env` in root.
+4. Uncomment the `COMPOSE_FILE=` line in `.env` to enable mounting of working copy code into the containers.
 4. Build a Docker image containing our backend code: `docker-compose build contract_observer`
 5. Create the database and migrate it to the latest schema: `docker-compose run contract_observer alembic upgrade head`
 6. Run the backend systems: `docker-compose up`. You can shut everything down with Ctrl+C at any time.

--- a/default.env
+++ b/default.env
@@ -1,6 +1,11 @@
+# This file contains environment variables needed to run this project.
+# Copy this file as .env to set the variables for docker-compose.
 HUEY_CONCURRENCY=3
 POSTGRES_DB=forkdelta
 POSTGRES_USER=root
 POSTGRES_PASSWORD=root
 HTTP_PROVIDER_URL=http://138.197.160.134:8545/
 WS_PROVIDER_URL=ws://138.197.160.134:8546/
+
+# Uncomment the following line to mount your working copy code into containers.
+#COMPOSE_FILE=docker-compose.yml:docker-compose.development.yml

--- a/docker-compose.development.yml
+++ b/docker-compose.development.yml
@@ -1,0 +1,23 @@
+##
+# This docker-compose file extends the default docker-compose.yml with
+# development settings.
+# Use
+#   COMPOSE_FILE=docker-compose.yml:docker-compose.development.yml
+# in your .env file to apply these overrides.
+version: '2'
+services:
+  contract_observer:
+    volumes:
+      - .:/usr/src/app
+
+  etherdelta_observer:
+    volumes:
+      - .:/usr/src/app
+
+  huey_consumer:
+    volumes:
+      - .:/usr/src/app
+
+  websocket_server:
+    volumes:
+      - .:/usr/src/app

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,6 +5,7 @@ services:
     build: .
     depends_on:
       - postgres
+      - redis
     environment:
       POSTGRES_DB: ${POSTGRES_DB}
       POSTGRES_USER: ${POSTGRES_USER}
@@ -13,8 +14,7 @@ services:
       WS_PROVIDER_URL: ${WS_PROVIDER_URL}
     links:
       - postgres
-    volumes:
-      - .:/usr/src/app
+      - redis
     command: >
       python3 -m app.services.contract_observer
 
@@ -23,6 +23,7 @@ services:
     build: .
     depends_on:
       - postgres
+      - redis
     environment:
       POSTGRES_DB: ${POSTGRES_DB}
       POSTGRES_USER: ${POSTGRES_USER}
@@ -30,8 +31,7 @@ services:
       HTTP_PROVIDER_URL: ${HTTP_PROVIDER_URL}
     links:
       - postgres
-    volumes:
-      - .:/usr/src/app
+      - redis
     command: >
       python3 -m app.services.etherdelta_observer
 
@@ -49,8 +49,6 @@ services:
     links:
       - postgres
       - redis
-    volumes:
-      - .:/usr/src/app
     command: >
       huey_consumer.py app.services.huey_consumer.huey -w ${HUEY_CONCURRENCY} -k greenlet
 
@@ -68,8 +66,6 @@ services:
       - postgres
     ports:
       - "8080:8080"
-    volumes:
-      - .:/usr/src/app
     command: >
       python3 -m app.services.websocket_server
 
@@ -79,6 +75,8 @@ services:
       POSTGRES_DB: ${POSTGRES_DB}
       POSTGRES_USER: ${POSTGRES_USER}
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+    volumes:
+      - /var/lib/postgresql/data
 
   redis:
     image: redis:4.0-alpine


### PR DESCRIPTION
This is a devops change. It's made on top of #22, see e6bc7ad for changes.

TL;DR: add `COMPOSE_FILE=docker-compose.yml:docker-compose.development.yml` to your `.env` to keep the current development environment behaviour.

We need a stable environment on staging/production, where we bake the source code into the image, and the code doesn't change if the working copy code changes. This is achieved by removing the directive of `docker-compose.yml` that mounts code into the containers. Because we still want to keep the old behaviour in development, we actually extract the code-mounting directive into `docker-compose.development.yml`, which is applied on top of `docker-compose.yml` using `COMPOSE_FILE` environment variable.

This PR:
* Moves development-environment config out of `docker-compose.yml` and into `docker-compose.development.yml`
* Adds some pointers on how that setup works.