### PR TITLE
Order sanity checks

### DIFF
--- a/app/services/etherdelta_observer.py
+++ b/app/services/etherdelta_observer.py
@@ -51,7 +51,7 @@ async def process_orders(orders):
     orders = list(filter(not_deleted_filter, orders))
     logger.debug("Filtered orders: %i", len(orders))
     v = OrderMessageValidatorEtherdelta()
-    warnings.filterwarnings("ignore", category=DeprecationWarning)     
+
     current_block = web3.eth.blockNumber # TODO: Introduce a strict timeout here; on failure allow order (todo copied from websocket_server.py)
     for order in orders:
         try:

--- a/app/services/etherdelta_observer.py
+++ b/app/services/etherdelta_observer.py
@@ -45,10 +45,6 @@ async def on_disconnect(io_client, event):
 
 
 
-import warnings
-from functools import wraps
-
-
 async def process_orders(orders):
     not_deleted_filter = lambda order: "deleted" not in order or not order["deleted"]
     logger.info("Processing %i orders", len(orders))

--- a/app/services/etherdelta_observer.py
+++ b/app/services/etherdelta_observer.py
@@ -43,36 +43,44 @@ async def on_error(io_client, event, error):
 async def on_disconnect(io_client, event):
     logger.info("ED API client disconnected from %s", io_client.ws_url)
 
+def validate_order(order, current_block=None):
+    """
+    Validates an order dictionary. Returns True if the order is valid, False otherwise.
+    """
 
-
-async def process_orders(orders):
-    not_deleted_filter = lambda order: "deleted" not in order or not order["deleted"]
-    logger.info("Processing %i orders", len(orders))
-    orders = list(filter(not_deleted_filter, orders))
-    logger.debug("Filtered orders: %i", len(orders))
     v = OrderMessageValidatorEtherdelta()
+    if not v.validate(order):
+        error_msg = "Invalid message format"
+        details_dict = dict(data=order, errors=v.errors)
+        logger.warning("ED order rejected: %s: %s", error_msg, details_dict)
+        return False
 
+    order_validated = v.document # Get data with validated and coerced values
+
+    if current_block and order_validated["expires"] <= current_block:
+        error_msg = "Cannot record order because it has already expired"
+        details_dict = { "blockNumber": current_block, "expires": order["expires"], "date": datetime.utcnow() }
+        logger.warning("ED Order rejected: %s: %s", error_msg, details_dict)
+        return False
+
+    if not order_signature_valid(order_validated):
+        logger.warning("ED Order rejected: Invalid signature: order = %s", order)
+        return False
+    return True
+
+from functools import partial
+async def process_orders(orders):
     current_block = web3.eth.blockNumber # TODO: Introduce a strict timeout here; on failure allow order (todo copied from websocket_server.py)
+
+    not_deleted_filter = lambda order: "deleted" not in order or not order["deleted"]
+    invalid_orders_filter = partial(validate_order, current_block=current_block)
+
+    logger.info("Processing %i orders", len(orders))
+    orders = list(filter(invalid_orders_filter, filter(not_deleted_filter, orders)))
+    logger.debug("Filtered orders: %i", len(orders))
+
     for order in orders:
         try:
-            if not v.validate(order):
-                error_msg = "Invalid message format"
-                details_dict = dict(data=order, errors=v.errors)
-                logger.warning("ED order rejected: %s: %s", error_msg, details_dict)
-                continue
-            else:
-                order_validated = v.document # Get data with validated and coerced values
-
-            if order_validated["expires"] <= current_block:
-                error_msg = "Cannot post order because it has already expired"
-                details_dict = { "blockNumber": current_block, "expires": order["expires"], "date": datetime.utcnow() }
-                logger.warning("ED Order rejected: %s: %s", error_msg, details_dict)
-                continue
-
-            if not order_signature_valid(order_validated):
-                logger.warning("ED Order rejected: Invalid signature: order = %s", order)
-                continue
-
             await record_order(order)
         except Exception as e:
             logger.critical("Error while processing order '%s'", order)

--- a/app/src/order_message_validator.py
+++ b/app/src/order_message_validator.py
@@ -19,9 +19,9 @@ def validate_0x_prefixed_hex_address(field, value, error):
 ORDER_MESSAGE_SCHEMA = {
     "contractAddr": { "type": "string", "required": True, "coerce": to_normalized_address, "validator": validate_0x_prefixed_hex_address },
     "tokenGet": { "type": "string", "required": True, "coerce": to_normalized_address, "validator": validate_0x_prefixed_hex_address },
-    "amountGet": { "type": "integer", "required": True, "coerce": str_to_decimal_to_int, "min": 0 },
-    "tokenGive": { "type": "string", "required": True, "coerce": to_normalized_address, "validator": validate_0x_prefixed_hex_address },
-    "amountGive": { "type": "integer", "required": True, "coerce": str_to_decimal_to_int, "min": 0 },
+    "amountGet": { "type": "integer", "required": True, "coerce": str_to_decimal_to_int, "min": 1 },
+    "tokenGive": { "type": "string", "required": True, "coerce": to_normalized_address, "validator": validate_0x_prefixed_hex_address, "not_equal": "tokenGet" }, 
+    "amountGive": { "type": "integer", "required": True, "coerce": str_to_decimal_to_int, "min": 1 },
     "expires": { "type": "integer", "required": True, "coerce": Web3.toInt, "min": 0 },
     "nonce": { "type": "integer", "required": True, "coerce": Web3.toInt, "min": 0 },
     "user": { "type": "string", "required": True, "coerce": to_normalized_address, "validator": validate_0x_prefixed_hex_address },
@@ -30,6 +30,38 @@ ORDER_MESSAGE_SCHEMA = {
     "s": { "type": "binary", "required": True, "coerce": hexstr_to_bytes, "minlength": 32, "maxlength": 32 },
 }
 
-class OrderMessageValidator(cerberus.Validator):
+ORDER_MESSAGE_SCHEMA_ETHERDELTA = {
+    "tokenGet": { "type": "string", "required": True, "coerce": to_normalized_address, "validator": validate_0x_prefixed_hex_address },
+    "amountGet": { "type": "integer", "required": True, "coerce": str_to_decimal_to_int, "min": 1 },
+    "tokenGive": { "type": "string", "required": True, "coerce": to_normalized_address, "validator": validate_0x_prefixed_hex_address,  "not_equal": "tokenGet" },
+    "amountGive": { "type": "integer", "required": True, "coerce": str_to_decimal_to_int, "min": 1 },
+    "expires": { "type": "integer", "required": True, "coerce": Web3.toInt, "min": 0 },
+    "nonce": { "type": "integer", "required": True, "coerce": Web3.toInt, "min": 0 },
+    "user": { "type": "string", "required": True, "coerce": to_normalized_address, "validator": validate_0x_prefixed_hex_address },
+    "v": { "type": "integer", "required": True },
+    "r": { "type": "binary", "required": True, "coerce": hexstr_to_bytes, "minlength": 32, "maxlength": 32 },
+    "s": { "type": "binary", "required": True, "coerce": hexstr_to_bytes, "minlength": 32, "maxlength": 32 },
+}
+
+class OrderMessageValidatorBase(cerberus.Validator):
+    def __init__(self, schema, *args, **kwargs):
+        super().__init__(schema, *args, **kwargs)
+    
+    def _validate_not_equal(self, other, field, value):
+        """Validates that the value of field does not equal the value of other
+        """        
+        if other not in self.document:
+            return False
+        if value == self.document[other]:
+            self._error(field, 
+                        "Field is not allowed to have same value as %s." % other)
+
+class OrderMessageValidator(OrderMessageValidatorBase):
     def __init__(self, *args, **kwargs):
         super().__init__(ORDER_MESSAGE_SCHEMA, *args, **kwargs)
+
+
+class OrderMessageValidatorEtherdelta(OrderMessageValidatorBase):
+    def __init__(self, *args, **kwargs):
+        super().__init__(ORDER_MESSAGE_SCHEMA_ETHERDELTA, *args, **kwargs)
+        self.allow_unknown = True

--- a/app/src/order_message_validator.py
+++ b/app/src/order_message_validator.py
@@ -20,7 +20,7 @@ ORDER_MESSAGE_SCHEMA = {
     "contractAddr": { "type": "string", "required": True, "coerce": to_normalized_address, "validator": validate_0x_prefixed_hex_address },
     "tokenGet": { "type": "string", "required": True, "coerce": to_normalized_address, "validator": validate_0x_prefixed_hex_address },
     "amountGet": { "type": "integer", "required": True, "coerce": str_to_decimal_to_int, "min": 1 },
-    "tokenGive": { "type": "string", "required": True, "coerce": to_normalized_address, "validator": validate_0x_prefixed_hex_address, "not_equal": "tokenGet" }, 
+    "tokenGive": { "type": "string", "required": True, "coerce": to_normalized_address, "validator": validate_0x_prefixed_hex_address },
     "amountGive": { "type": "integer", "required": True, "coerce": str_to_decimal_to_int, "min": 1 },
     "expires": { "type": "integer", "required": True, "coerce": Web3.toInt, "min": 0 },
     "nonce": { "type": "integer", "required": True, "coerce": Web3.toInt, "min": 0 },
@@ -33,7 +33,7 @@ ORDER_MESSAGE_SCHEMA = {
 ORDER_MESSAGE_SCHEMA_ETHERDELTA = {
     "tokenGet": { "type": "string", "required": True, "coerce": to_normalized_address, "validator": validate_0x_prefixed_hex_address },
     "amountGet": { "type": "integer", "required": True, "coerce": str_to_decimal_to_int, "min": 1 },
-    "tokenGive": { "type": "string", "required": True, "coerce": to_normalized_address, "validator": validate_0x_prefixed_hex_address,  "not_equal": "tokenGet" },
+    "tokenGive": { "type": "string", "required": True, "coerce": to_normalized_address, "validator": validate_0x_prefixed_hex_address },
     "amountGive": { "type": "integer", "required": True, "coerce": str_to_decimal_to_int, "min": 1 },
     "expires": { "type": "integer", "required": True, "coerce": Web3.toInt, "min": 0 },
     "nonce": { "type": "integer", "required": True, "coerce": Web3.toInt, "min": 0 },
@@ -46,15 +46,6 @@ ORDER_MESSAGE_SCHEMA_ETHERDELTA = {
 class OrderMessageValidatorBase(cerberus.Validator):
     def __init__(self, schema, *args, **kwargs):
         super().__init__(schema, *args, **kwargs)
-    
-    def _validate_not_equal(self, other, field, value):
-        """Validates that the value of field does not equal the value of other
-        """        
-        if other not in self.document:
-            return False
-        if value == self.document[other]:
-            self._error(field, 
-                        "Field is not allowed to have same value as %s." % other)
 
 class OrderMessageValidator(OrderMessageValidatorBase):
     def __init__(self, *args, **kwargs):

--- a/app/src/order_signature.py
+++ b/app/src/order_signature.py
@@ -15,12 +15,12 @@ def order_signature_valid(message):
     eth_signature_prefix = Web3.toBytes(text="\x19Ethereum Signed Message:\n32")
     hash_bytes = Web3.toBytes(hexstr=make_order_hash(message))
 
-    signature_base = Web3.sha3(Web3.toHex(eth_signature_prefix + hash_bytes))
+    signature_base = Web3.sha3(hexstr=Web3.toHex(eth_signature_prefix + hash_bytes))
 
     recovered_address = ecrecover(
         Web3.toBytes(hexstr=signature_base),
         message["v"],
-        Web3.toInt(message["r"]),
-        Web3.toInt(message["s"]))
+        Web3.toInt(hexstr=Web3.toHex(message["r"])), # Convert from bytes to hex because sending bytes to toInt is deprecated behaviour, apparently
+        Web3.toInt(hexstr=Web3.toHex(message["s"])))
 
     return to_normalized_address(recovered_address) == to_normalized_address(message["user"])


### PR DESCRIPTION
* Changed cerberus order validation for amountGet and amountGive to ">=1" (was >=0).
* Added cerberus  validation so that "tokenGet != tokenGive". (Trap orders for poorly written bots ending up buying 10 X for 100 X)
* Enabled cerberus validation for orders coming from ED (with slightly different rules)
* Added expiration and signature validation for orders coming from ED

This should fix #42 and #45. 