### PR TITLE
Require base in orders and trades

### DIFF
--- a/app/services/etherdelta_observer.py
+++ b/app/services/etherdelta_observer.py
@@ -57,6 +57,12 @@ def validate_order(order, current_block=None):
 
     order_validated = v.document # Get data with validated and coerced values
 
+    # Require one side of the order to be base currency
+    if order_validated["tokenGet"] != ZERO_ADDR and order_validated["tokenGive"] != ZERO_ADDR:
+        error_msg = "Cannot post order with pair {}-{}: neither is a base currency".format(order_validated["tokenGet"], order_validated["tokenGive"])
+        logger.warning("ED order rejected: %s", error_msg)
+        return
+
     if current_block and order_validated["expires"] <= current_block:
         error_msg = "Cannot record order because it has already expired"
         details_dict = { "blockNumber": current_block, "expires": order["expires"], "date": datetime.utcnow() }

--- a/app/services/etherdelta_observer.py
+++ b/app/services/etherdelta_observer.py
@@ -63,14 +63,16 @@ def validate_order(order, current_block=None):
         logger.warning("ED order rejected: %s", error_msg)
         return
 
+    # Require order to be non-expired
     if current_block and order_validated["expires"] <= current_block:
         error_msg = "Cannot record order because it has already expired"
-        details_dict = { "blockNumber": current_block, "expires": order["expires"], "date": datetime.utcnow() }
+        details_dict = { "blockNumber": current_block, "expires": order_validated["expires"], "date": datetime.utcnow().isoformat() }
         logger.warning("ED Order rejected: %s: %s", error_msg, details_dict)
         return False
 
+    # Require a valid signature
     if not order_signature_valid(order_validated):
-        logger.warning("ED Order rejected: Invalid signature: order = %s", order)
+        logger.warning("ED Order rejected: Invalid signature: raw_order = %s, order = %s", order, order_validated)
         return False
     return True
 

--- a/app/services/websocket_server.py
+++ b/app/services/websocket_server.py
@@ -455,6 +455,13 @@ async def handle_order(sid, data):
         await sio.emit("messageResult", [422, error_msg], room=sid)
         return
 
+    # Require one side of the order to be base currency
+    if message["tokenGet"] != ZERO_ADDR and message["tokenGive"] != ZERO_ADDR:
+        error_msg = "Cannot post order with pair {}-{}: neither is a base currency".format(message["tokenGet"], message["tokenGive"])
+        logger.warning("Order rejected: %s", error_msg)
+        await sio.emit("messageResult", [422, error_msg], room=sid)
+        return
+
     # Require new orders to be non-expired
     current_block = App().web3.eth.blockNumber # TODO: Introduce a strict timeout here; on failure allow order
     if message["expires"] <= current_block:

--- a/app/services/websocket_server.py
+++ b/app/services/websocket_server.py
@@ -89,10 +89,10 @@ def format_trade(trade):
         }
 
 async def get_trades(token_hexstr, user_hexstr=None):
-    where = '("token_give" = $1 OR "token_get" = $1)'
-    placeholder_args = [Web3.toBytes(hexstr=token_hexstr), ]
+    where = '(("token_give" = $1 AND "token_get" = $2) OR ("token_get" = $1 AND "token_give" = $2))'
+    placeholder_args = [Web3.toBytes(hexstr=token_hexstr), ZERO_ADDR_BYTES]
     if user_hexstr:
-        where += ' AND ("addr_give" = $2 OR "addr_get" = $2)'
+        where += ' AND ("addr_give" = $3 OR "addr_get" = $3)'
         placeholder_args.append(Web3.toBytes(hexstr=user_hexstr))
 
     async with App().db.acquire_connection() as conn:
@@ -112,10 +112,11 @@ async def get_new_trades(created_after):
             """
             SELECT *
             FROM trades
-            WHERE ("date" >= $1)
+            WHERE ("date" >= $1) AND ("token_give" = $2 OR "token_get" = $2)
             ORDER BY block_number DESC, date DESC
             """,
-            created_after)
+            created_after,
+            ZERO_ADDR_BYTES)
 
 def format_transfer(transfer):
     contract = ERC20Token(transfer["token"])
@@ -207,10 +208,10 @@ async def get_updated_orders(updated_after, token_give_hexstr=None, token_get_he
     placeholder_args = [updated_after]
 
     if token_give_hexstr:
-        where += 'AND ("token_give" = $2)'
+        where += ' AND ("token_give" = $2)'
         placeholder_args.append(Web3.toBytes(hexstr=token_give_hexstr))
     elif token_get_hexstr:
-        where += 'AND ("token_get" = $2)'
+        where += ' AND ("token_get" = $2)'
         placeholder_args.append(Web3.toBytes(hexstr=token_get_hexstr))
 
     async with App().db.acquire_connection() as conn:

--- a/app/src/order_message_validator.py
+++ b/app/src/order_message_validator.py
@@ -51,7 +51,6 @@ class OrderMessageValidator(OrderMessageValidatorBase):
     def __init__(self, *args, **kwargs):
         super().__init__(ORDER_MESSAGE_SCHEMA, *args, **kwargs)
 
-
 class OrderMessageValidatorEtherdelta(OrderMessageValidatorBase):
     def __init__(self, *args, **kwargs):
         super().__init__(ORDER_MESSAGE_SCHEMA_ETHERDELTA, *args, **kwargs)


### PR DESCRIPTION
This PR:
* Requires incoming orders have base currency on one side of the trade
* Filters out orders and trades that don't have a base currency side from API responses and ticker computation