### PR TITLE
 Ignore signatures for orders created from Cancel events

### DIFF
--- a/app/tasks/update_order.py
+++ b/app/tasks/update_order.py
@@ -101,6 +101,7 @@ async def update_order(order):
                     Web3.toHex(order["signature"]),
                     amount_fill, available_volume)
 
+EMPTY_BYTES32 = b'0' * 32
 def order_as_args(order):
     return (
         Web3.toHex(order["token_get"]),
@@ -110,6 +111,6 @@ def order_as_args(order):
         Web3.toInt(order["expires"]),
         Web3.toInt(order["nonce"]),
         Web3.toHex(order["user"]),
-        order["v"],
-        order["r"],
-        order["s"])
+        order["v"] or 0,
+        order["r"] or EMPTY_BYTES32,
+        order["s"] or EMPTY_BYTES32)


### PR DESCRIPTION
This PR:
* changes the behaviour of Cancel event recorder: it now skips recording the order signature
* allows for orders without signatures in order updater task

Fixes #44.